### PR TITLE
Ts authentication

### DIFF
--- a/src/scripts/Nutshell.js
+++ b/src/scripts/Nutshell.js
@@ -1,3 +1,6 @@
+const contentTarget = document.querySelector(".container--left")
+
 export const Nutshell = () => {
     // Render all your UI components here
+    contentTarget.innerHTML = "<p>Welcome to Nutshell!</p>"
 }

--- a/src/scripts/auth/LoginForm.js
+++ b/src/scripts/auth/LoginForm.js
@@ -1,8 +1,11 @@
+import { Nutshell } from "../Nutshell.js"
+
 const contentTarget = document.querySelector(".auth--login")
 const eventHub = document.querySelector(".container")
 
 eventHub.addEventListener("userAuthenticated", e => {
     contentTarget.innerHTML = ""
+    Nutshell()
 })
 
 eventHub.addEventListener("click", e => {

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -5,7 +5,7 @@ import { getUsers } from "./users/UserDataProvider.js"
 import { getEvents} from "./events/EventDataProvider.js"
 
 /*
-1. Check if the user is authenticated by loing in sokession storage for `activeUser`
+1. Check if the user is authenticated by looking in session storage for `activeUser`
 2. If so, render the Nutshell component
 3. If not, render the login and registration forms
 4. Also, if the user authenticates, and the login form is initially shown

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -5,7 +5,7 @@ import { getUsers } from "./users/UserDataProvider.js"
 import { getEvents} from "./events/EventDataProvider.js"
 
 /*
-1. Check if the user is authenticated by looking in session storage for `activeUser`
+1. Check if the user is authenticated by loing in sokession storage for `activeUser`
 2. If so, render the Nutshell component
 3. If not, render the login and registration forms
 4. Also, if the user authenticates, and the login form is initially shown
@@ -14,3 +14,11 @@ ensure that the Nutshell component gets rendered
 
 getUsers()
 getEvents()
+// LoginForm()
+if (!sessionStorage.length) {
+    LoginForm()
+    RegisterForm()
+}
+else {
+    Nutshell()
+}


### PR DESCRIPTION
# Description
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
Fixes # (issue)

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# Testing Instructions
### Setup
1. `git fetch --all`
1. `git checkout ts-authentication`
1. `serve`
1. Open web app via `localhost`.

### Test 1 (See Login/Registration Form)
#### Conditions:
Given a user wants to use Nutshell
When the user first accesses the application
Then the user should see a login form
And the user should see a registration form

1. Verify that your session storage in Developer Tools is clear.
2. You should see a login form and a registration form. If this is true, this Test 1 passes.

### Test 2 (Log In)
#### Conditions:
Given the user fills out the login form
When the user clicks the Login button
And the username exists
And the password matches the stored password for the username
Then the login and register form should disappear and the main Nutshell components should be rendered

1. Verify that your session storage in Developer Tools is clear.
1. Verify that your `database.json` file has an endpoint for users, with the provided sample data. It should look like this:
<img width="259" alt="Screen Shot 2020-11-17 at 12 19 04 PM" src="https://user-images.githubusercontent.com/18717331/99430585-26d88f00-28cf-11eb-8807-6c0f046a5afb.png">
3. Attempt to login with the username "Steve". Note: Username capitalization is significant, so ensure you capitalize.
4. Upon clicking the Log In button, you should be presented with Nutshell UI, which should look like this:
<img width="511" alt="Screen Shot 2020-11-17 at 12 23 18 PM" src="https://user-images.githubusercontent.com/18717331/99431017-b1b98980-28cf-11eb-9c48-9c6f4469e9b6.png">
If this is true, this Test 2 passes.

### Test 3 (Registration)
#### Conditions:
Given the user fills out the registration form
When the user clicks the Register button
And the username is unique
Then the login and register form should disappear and the main Nutshell components should be rendered

1. Verify that your session storage in Developer Tools is clear.
1. You should see a login form and a registration form.
1. Attempt to register a new user, using the username "Steve", you should get a popup alert menu that says, "Username already exists!"
1. Attempt to register a new user, using any username other than "Steve".
1. Upon clicking the Log In button, you should be presented with Nutshell UI, which should look like this:
<img width="511" alt="Screen Shot 2020-11-17 at 12 23 18 PM" src="https://user-images.githubusercontent.com/18717331/99431017-b1b98980-28cf-11eb-9c48-9c6f4469e9b6.png">
If ALL of these steps are true, Test 3 passes.

### Test 4 (Bypass Login/Registration Form if activeUser exists)
#### Conditions:
Given a user wants to use Nutshell
When the user has previously authenticated (i.e. a activeUser token exists in session storage)
Then the user should see the Nutshell UI components

1. Log in as an existing user, or register a new user account.
1. Verify that your session storage in Developer Tools contains an activeUser. It should look like this: 
<img width="631" alt="Screen Shot 2020-11-17 at 12 33 36 PM" src="https://user-images.githubusercontent.com/18717331/99431973-2640f800-28d1-11eb-9948-dbef77eb22b2.png">
3. At this point you should be seeing the Nutshell UI from Test 3.
4. Refresh the web app. You should still see the Nutshell UI from Test 3. If this is true, Test 4 passes.

If Tests 1-4 pass, this code is ready to merge into master.

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added test instructions that prove my fix is effective or that my feature works
